### PR TITLE
Add script to check Apex API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # SFDataCheck
+
+This repository contains utilities for validating Salesforce metadata. The
+`check_api_version.py` script reports Apex classes whose API version is below
+`45.0`.
+
+```bash
+python3 check_api_version.py
+```
+

--- a/check_api_version.py
+++ b/check_api_version.py
@@ -1,0 +1,34 @@
+import os
+import xml.etree.ElementTree as ET
+
+# Directory containing the metadata
+BASE_DIR = os.path.join('Salesforce', 'force-app', 'main', 'default', 'classes')
+
+THRESHOLD_VERSION = 45.0
+
+def find_low_api_version_files(base_dir=BASE_DIR, threshold=THRESHOLD_VERSION):
+    low_version_files = []
+    for root, _, files in os.walk(base_dir):
+        for f in files:
+            if f.endswith('.cls-meta.xml'):
+                full_path = os.path.join(root, f)
+                try:
+                    tree = ET.parse(full_path)
+                    api_version = tree.findtext('.//apiVersion')
+                    if api_version is None:
+                        continue
+                    version = float(api_version)
+                    if version < threshold:
+                        low_version_files.append((full_path, version))
+                except Exception as e:
+                    print(f"Error parsing {full_path}: {e}")
+    return low_version_files
+
+if __name__ == '__main__':
+    results = find_low_api_version_files()
+    if not results:
+        print(f"No Apex classes with API version below {THRESHOLD_VERSION} found.")
+    else:
+        print(f"Apex classes with API version below {THRESHOLD_VERSION}:")
+        for path, version in results:
+            print(f"{path}: {version}")


### PR DESCRIPTION
## Summary
- add `check_api_version.py` to list Apex classes below API version 45.0
- update README with instructions

## Testing
- `python3 check_api_version.py`